### PR TITLE
Fix: 'Logger' object has no attribute 'getLogger'

### DIFF
--- a/app.py
+++ b/app.py
@@ -905,7 +905,7 @@ logger.debug(f"Starting web server at {protocol}://{args.host}:{args.port}")
 server = pywsgi.WSGIServer(
     (args.host, args.port), app, handler_class=WebSocketHandler, **server_kwargs
 )
-logger.getLogger("geventwebsocket").setLevel(logging.WARN)
+logging.getLogger("geventwebsocket").setLevel(logging.WARN)
 
 try:
     server.serve_forever()


### PR DESCRIPTION
Fix for a bug in the newest Docker container