### PR TITLE
Upgrade pip in create-venv.sh script

### DIFF
--- a/create-venv.sh
+++ b/create-venv.sh
@@ -209,7 +209,7 @@ export LD_LIBRARY_PATH="${venv}/lib:${LD_LIBRARY_PATH}"
 source "${venv}/bin/activate"
 
 echo "Upgrading pip"
-pip install --upgrade pip
+"${PYTHON}" -m pip install --upgrade pip
 
 echo "Installing Python requirements"
 "${PYTHON}" -m pip install wheel setuptools

--- a/create-venv.sh
+++ b/create-venv.sh
@@ -208,6 +208,9 @@ export LD_LIBRARY_PATH="${venv}/lib:${LD_LIBRARY_PATH}"
 # shellcheck source=/dev/null
 source "${venv}/bin/activate"
 
+echo "Upgrading pip"
+pip install --upgrade pip
+
 echo "Installing Python requirements"
 "${PYTHON}" -m pip install wheel setuptools
 "${PYTHON}" -m pip install requests


### PR DESCRIPTION
The installation of flit-core fails in a virtual environment on Ubuntu 19.10 amd64. Upgrading pip in the create-venv.sh script fixes this.