### PR TITLE
Show URL when download fails

### DIFF
--- a/download-dependencies.sh
+++ b/download-dependencies.sh
@@ -54,7 +54,7 @@ function maybe_download {
         fi
 
         mkdir -p "$(dirname "$2")"
-        curl -sSfL -o "$2" "$1"
+        curl -sSfL -o "$2" "$1" || { echo "Can't download $1"; exit 1; }
         echo "$1 => $2"
     fi
 }


### PR DESCRIPTION
My initial gripe with https://github.com/synesthesiam/rhasspy/issues/65 was that the error message wasn't descriptive enough: I had no idea which URL it was complaining about. With this fix, download-dependencies.sh shows the URL when a download fails, which will make debugging download problems easier.