### PR TITLE
Docs: Beginning of MQTT reference

### DIFF
--- a/docs/audio-output.md
+++ b/docs/audio-output.md
@@ -27,7 +27,7 @@ See `rhasspy.audio_player.APlayAudioPlayer` for details.
 Publishes WAV data to the `hermes/audioServer/<SITE_ID>/playBytes/<REQUEST_ID>` topic ([Hermes protocol](https://docs.snips.ai/ressources/hermes-protocol)).
 This allows Rhasspy to send audio to [Snips.AI](https://snips.ai/).
 
-Rhasspy will always try to send 16 kHz, 16-bit mono audio.
+Rhasspy will by default send 16 kHz, 16-bit mono audio, unless specified otherwise.
 The request id is generated each time a sound is played using `uuid.uuid4`.
 
 Add to your [profile](profiles.md):

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -121,7 +121,7 @@ Application authors may want to use the [rhasspy-client](https://pypi.org/projec
 Rhasspy implements part of the [Hermes](https://docs.snips.ai/reference/hermes) protocol. Various services of Rhasspy can be configured to pass along MQTT messages or to react to MQTT messages following the Hermes protocol.
 
 * `hermes/audioServer/<SITE_ID>/playBytes/<REQUEST_ID>`
-    * Rhasspy publishes 16 kHz, 16-bit mono audio in WAV format to this topic.
+    * Rhasspy publishes audio in WAV format to this topic. By default it is 16 kHz, 16-bit mono for compatibility reaons, but other types are possible too.
     * `SITE_ID` is set in Rhasspy's `mqtt` configuration.
     * `REQUEST_ID` is generated using `uuid.uuid4` each time a sound is played.
 * `hermes/audioServer/<SITE_ID>/audioFrame`

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -3,6 +3,7 @@
 * [Supported Languages](#supported-languages)
 * [HTTP API](#http-api)
 * [Websocket API](#websocket-api)
+* [MQTT API](#mqtt-api)
 * [Command Line](#command-line)
 * [Profile Settings](#profile-settings)
 
@@ -114,6 +115,16 @@ Application authors may want to use the [rhasspy-client](https://pypi.org/projec
     * Listen for recognized intents published as JSON
 * `/api/events/log`
     * Listen for log messages published as plain text
+
+## MQTT API
+
+Rhasspy implements part of the [Hermes](https://docs.snips.ai/reference/hermes) protocol. Various services of Rhasspy can be configured to pass along MQTT messages or to react to MQTT messages following the Hermes protocol.
+
+* `hermes/audioServer/<SITE_ID>/playBytes/<REQUEST_ID>`
+    * Rhasspy publishes 16 kHz, 16-bit mono audio to this topic.
+    * `SITE_ID` is set in Rhasspy's `mqtt` configuration.
+    * `REQUEST_ID` is generated using `uuid.uuid4` each time a sound is played.
+* More to follow
 
 ## Command Line
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -121,9 +121,27 @@ Application authors may want to use the [rhasspy-client](https://pypi.org/projec
 Rhasspy implements part of the [Hermes](https://docs.snips.ai/reference/hermes) protocol. Various services of Rhasspy can be configured to pass along MQTT messages or to react to MQTT messages following the Hermes protocol.
 
 * `hermes/audioServer/<SITE_ID>/playBytes/<REQUEST_ID>`
-    * Rhasspy publishes 16 kHz, 16-bit mono audio to this topic.
+    * Rhasspy publishes 16 kHz, 16-bit mono audio in WAV format to this topic.
     * `SITE_ID` is set in Rhasspy's `mqtt` configuration.
     * `REQUEST_ID` is generated using `uuid.uuid4` each time a sound is played.
+* `hermes/audioServer/<SITE_ID>/audioFrame`
+    * Rhasspy listens to this topic for WAV data. Audio is automatically converted to 16 kHz, 16-bit mono audio and played.
+    * `SITE_ID` is set in Rhasspy's `mqtt` configuration.
+* `hermes/asr/startListening`
+    * Rhasspy wakes up and starts recording on receiving this topic.
+    * The payload is a JSON object with a `siteId` key that holds Rhasspy's site ID.
+* `hermes/asr/stopListening`
+    * Rhasspy stops recording and processes the voice command on receiving this topic.
+    * The payload is a JSON object with a `siteId` key that holds Rhasspy's site ID.
+* `hermes/intent/<INTENT_NAME>`
+    * Rhasspy publishes a message to this topic on recognition of an intent.
+    The payload is a JSON object with the recognized intent, entities and text.
+* `hermes/nlu/intentNotRecognized`
+    * Rhasspy publishes a message to this topic when it doesn't recognize an intent.
+* `hermes/asr/textCaptured`
+    * Rhasspy publishes a transcription to this topic each time a voice command is recognized.
+* `hermes/hotword/<WAKEWORD_ID>/detected`
+    * Rhasspy wakes up when a message is received on this topic.
 * More to follow
 
 ## Command Line

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -135,7 +135,7 @@ Rhasspy implements part of the [Hermes](https://docs.snips.ai/reference/hermes) 
     * The payload is a JSON object with a `siteId` key that holds Rhasspy's site ID.
 * `hermes/intent/<INTENT_NAME>`
     * Rhasspy publishes a message to this topic on recognition of an intent.
-    The payload is a JSON object with the recognized intent, entities and text.
+    * The payload is a JSON object with the recognized intent, entities and text.
 * `hermes/nlu/intentNotRecognized`
     * Rhasspy publishes a message to this topic when it doesn't recognize an intent.
 * `hermes/asr/textCaptured`


### PR DESCRIPTION
With the current interest in Rhasspy implementing more of the Hermes protocol, I'm going to document the current MQTT/Hermes implementation of Rhasspy on the reference page. This is just the beginning, I'm going to update it in the next days. You can wait with merging until I have added more.