### PR TITLE
Various documentation fixes

### DIFF
--- a/docs/audio-input.md
+++ b/docs/audio-input.md
@@ -22,7 +22,7 @@ Add to your [profile](profiles.md):
 ```
 
 Set `microphone.pyaudio.device` to a PyAudio device number or leave blank for the default device.
-Streams 30ms chunks of 16-bit, 16 Khz mono audio by default (480 frames).
+Streams 30ms chunks of 16-bit, 16 kHz mono audio by default (480 frames).
 
 See `rhasspy.audio_recorder.PyAudioRecorder` for details.
 
@@ -80,7 +80,7 @@ See `rhasspy.audio_recorder.HermesAudioRecorder` for details.
 
 ## HTTP Stream
 
-Accepts chunks of 16-bit 16Khz mono audio via an HTTP POST stream (assumes [chunked transfer encoding](https://en.wikipedia.org/wiki/Chunked_transfer_encoding)).
+Accepts chunks of 16-bit 16 kHz mono audio via an HTTP POST stream (assumes [chunked transfer encoding](https://en.wikipedia.org/wiki/Chunked_transfer_encoding)).
 
 Add to your [profile](profiles.md):
 
@@ -95,7 +95,7 @@ Add to your [profile](profiles.md):
 }
 ```
 
-Set `microphone.http.stop_after` to one of "never", "text", or "intent". When set to "never", you can continously stream (chunked) audio into Rhasspy across multiple voice commands. When set to "text" or "intent", the stream will be closed when the first voice command has been transcribed ("text") or recognized ("intent"). Once closed, you can perform an HTTP GET request to the stream URL to retrieve the result (text for transcriptions or JSON for intent).
+Set `microphone.http.stop_after` to one of "never", "text", or "intent". When set to "never", you can continuously stream (chunked) audio into Rhasspy across multiple voice commands. When set to "text" or "intent", the stream will be closed when the first voice command has been transcribed ("text") or recognized ("intent"). Once closed, you can perform an HTTP GET request to the stream URL to retrieve the result (text for transcriptions or JSON for intent).
 
 Note that `microphone.http.port` must be different than Rhasspy's webserver port (usually 12101).
 
@@ -122,7 +122,7 @@ Set `microphone.gstreamer.pipeline` to your GStreamer pipeline **without a sink*
 udpsrc port=12333 ! rawaudioparse use-sink-caps=false format=pcm pcm-format=s16le sample-rate=16000 num-channels=1 ! queue ! audioconvert ! audioresample
 ```
 
-which "simply" receives raw 16-bit 16khz audio chunks via UDP port 12333. You could stream microphone audio to Rhasspy from another machine by running the following terminal command:
+which "simply" receives raw 16-bit 16 kHz audio chunks via UDP port 12333. You could stream microphone audio to Rhasspy from another machine by running the following terminal command:
 
 ```bash
 gst-launch-1.0 \

--- a/docs/audio-input.md
+++ b/docs/audio-input.md
@@ -52,7 +52,7 @@ See `rhasspy.audio_recorder.ARecordAudioRecorder` for details.
 
 ## MQTT/Hermes
 
-Listens to the `hermes/audioServer/<SITE_ID>/audioFrame` topic for WAV data ([Hermes protocol](https://docs.snips.ai/ressources/hermes-protocol)).
+Listens to the `hermes/audioServer/<SITE_ID>/audioFrame` topic for WAV data ([Hermes protocol](https://docs.snips.ai/reference/hermes)).
 This allows Rhasspy to receive audio from [Snips.AI](https://snips.ai/).
 Audio data is automatically converted to 16-bit, 16 kHz mono with [sox](http://sox.sourceforge.net).
 

--- a/docs/audio-output.md
+++ b/docs/audio-output.md
@@ -25,7 +25,7 @@ See `rhasspy.audio_player.APlayAudioPlayer` for details.
 
 ## MQTT/Hermes
 
-Publishes WAV data to the `hermes/audioServer/<SITE_ID>/playBytes/<REQUEST_ID>` topic ([Hermes protocol](https://docs.snips.ai/ressources/hermes-protocol)).
+Publishes WAV data to the `hermes/audioServer/<SITE_ID>/playBytes/<REQUEST_ID>` topic ([Hermes protocol](https://docs.snips.ai/reference/hermes)).
 This allows Rhasspy to send audio to [Snips.AI](https://snips.ai/).
 
 Rhasspy will by default send 16 kHz, 16-bit mono audio, unless specified otherwise.

--- a/docs/command-listener.md
+++ b/docs/command-listener.md
@@ -64,7 +64,7 @@ See `rhasspy.command_listener.OneShotCommandListener` for details.
 
 ## MQTT/Hermes
 
-Subscribes to the `hermes/asr/startListening` and `hermes/asr/stopListening` topics ([Hermes protocol](https://docs.snips.ai/ressources/hermes-protocol)).
+Subscribes to the `hermes/asr/startListening` and `hermes/asr/stopListening` topics ([Hermes protocol](https://docs.snips.ai/reference/hermes)).
 This allows Rhasspy to be controlled by [Snips.AI](https://snips.ai/).
 
 Wakes up Rhasspy when `startListening` is received and starts recording. Stops recording when `stopListening` is received and processes the voice command.

--- a/docs/index.md
+++ b/docs/index.md
@@ -41,7 +41,7 @@ Ready to try Rhasspy? Follow the steps below and check out the [tutorials](tutor
 2. Choose an [installation method](installation.md)
 3. Access the [web interface](usage.md#web-interface) to download a profile
 4. Author your [custom voice commands](training.md) and train Rhasspy
-5. Connect Rhasspy to [Home Assistant](usage.md#home-assistant) or a [Node-RED](usage.md#noe-red) flow
+5. Connect Rhasspy to [Home Assistant](usage.md#home-assistant) or a [Node-RED](usage.md#node-red) flow
 
 ## Supported Languages
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,7 +38,7 @@ Rhasspy is <strong>optimized for</strong>:
 Ready to try Rhasspy? Follow the steps below and check out the [tutorials](tutorials.md).
 
 1. Make sure you have the [necessary hardware](hardware.md)
-2. Choose an [installation method](install.md)
+2. Choose an [installation method](installation.md)
 3. Access the [web interface](usage.md#web-interface) to download a profile
 4. Author your [custom voice commands](training.md) and train Rhasspy
 5. Connect Rhasspy to [Home Assistant](usage.md#home-assistant) or a [Node-RED](usage.md#noe-red) flow

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -83,7 +83,7 @@ If all is well, the web interface will be available at [http://localhost:12101](
 
 At its core, Rhasspy requires:
 
-* Linux (preferrably Debian)
+* Linux (preferably Debian)
 * Python 3.6 or higher
 
 To actually use any components, however, requires a lot of [extra software](about.md#supporting-tools).

--- a/docs/intent-recognition.md
+++ b/docs/intent-recognition.md
@@ -157,7 +157,7 @@ See `rhasspy.intent.HomeAssistantConversationRecognizer` for details.
 
 ## MQTT/Hermes
 
-Publishes intent recognitions/failures to `hermes/intent/<INTENT_NAME>` or `hermes/nlu/intentNotRecognized` ([Hermes protocol](https://docs.snips.ai/ressources/hermes-protocol)).
+Publishes intent recognitions/failures to `hermes/intent/<INTENT_NAME>` or `hermes/nlu/intentNotRecognized` ([Hermes protocol](https://docs.snips.ai/reference/hermes)).
 
 This is enabled by default and controlled by the `mqtt.publish_intents` setting in your [profile](profiles.md).
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -534,7 +534,7 @@ All available profile sections and settings are listed below:
     * `stop_after` - one of "never", "text", or "intent" ([see documentation](audio-input.md#http-stream))
   * `gstreamer` - configuration for GStreamer audio recorder
     * `pipeline` - GStreamer pipeline (e.g., `FILTER ! FILTER ! ...`) without sink
-  * `hermes` - configuration for MQTT "microphone" ([Hermes protocol](https://docs.snips.ai/ressources/hermes-protocol))
+  * `hermes` - configuration for MQTT "microphone" ([Hermes protocol](https://docs.snips.ai/reference/hermes))
     * Subscribes to WAV data from `hermes/audioServer/<SITE_ID>/audioFrame`
     * Requires MQTT to be enabled
 * `sounds` - configuration for feedback sounds from Rhasspy
@@ -543,7 +543,7 @@ All available profile sections and settings are listed below:
   * `recorded` - path to WAV file to play when a command finishes recording
   * `aplay` - configuration for ALSA speakers
     * `device` - name of ALSA device (see `aplay -L`) to use or empty for default device
-  * `hermes` - configuration for MQTT "speakers" ([Hermes protocol](https://docs.snips.ai/ressources/hermes-protocol))
+  * `hermes` - configuration for MQTT "speakers" ([Hermes protocol](https://docs.snips.ai/reference/hermes))
     * WAV data published to `hermes/audioServer/<SITE_ID>/playBytes/<REQUEST_ID>`
     * Requires MQTT to be enabled
 * `command`
@@ -562,7 +562,7 @@ All available profile sections and settings are listed below:
   * `command` - configuration for external voice command program
     * `program` - path to executable
     * `arguments` - list of arguments to pass to program
-  * `hermes` - configuration for MQTT-based voice command system that listens betweens `startListening` and `stopListening` commands ([Hermes protocol](https://docs.snips.ai/ressources/hermes-protocol))
+  * `hermes` - configuration for MQTT-based voice command system that listens betweens `startListening` and `stopListening` commands ([Hermes protocol](https://docs.snips.ai/reference/hermes))
     * `timeout_sec` - maximum number of seconds before stopping
 * `handle`
   * `system` - which intent handling system to use (`hass`, `command`, or `dummy`)
@@ -572,14 +572,14 @@ All available profile sections and settings are listed below:
     * `arguments` - list of arguments to pass to program
   * `remote` - configuration for remote HTTP intent handler
     * `url` - URL to POST intent JSON to and receive response JSON from
-* `mqtt` - configuration for MQTT ([Hermes protocol](https://docs.snips.ai/ressources/hermes-protocol))
+* `mqtt` - configuration for MQTT ([Hermes protocol](https://docs.snips.ai/reference/hermes))
   * `enabled` - true if MQTT client should be started
   * `host` - MQTT host
   * `port` - MQTT port
   * `username` - MQTT username (blank for anonymous)
   * `password` - MQTT password
   * `reconnect_sec` - number of seconds before client will reconnect
-  * `site_id` - ID of site ([Hermes protocol](https://docs.snips.ai/ressources/hermes-protocol))
+  * `site_id` - ID of site ([Hermes protocol](https://docs.snips.ai/reference/hermes))
   * `publish_intents` - true if intents are published to MQTT
 * `download` - configuration for profile file downloading
   * `cache_dir` - directory in your profile where downloaded files are cached

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -121,7 +121,7 @@ Application authors may want to use the [rhasspy-client](https://pypi.org/projec
 Rhasspy implements part of the [Hermes](https://docs.snips.ai/reference/hermes) protocol. Various services of Rhasspy can be configured to pass along MQTT messages or to react to MQTT messages following the Hermes protocol.
 
 * `hermes/audioServer/<SITE_ID>/playBytes/<REQUEST_ID>`
-  * Rhasspy publishes audio in WAV format to this topic. By default it is 16 kHz, 16-bit mono for compatibility reaons, but other types are possible too.
+  * Rhasspy publishes audio in WAV format to this topic. By default it is 16 kHz, 16-bit mono for compatibility reasons, but other types are possible too.
   * `SITE_ID` is set in Rhasspy's `mqtt` configuration.
   * `REQUEST_ID` is generated using `uuid.uuid4` each time a sound is played.
 * `hermes/audioServer/<SITE_ID>/audioFrame`
@@ -392,7 +392,7 @@ All available profile sections and settings are listed below:
   * `system` - name of speech to text system (`pocketsphinx`, `remote`, `command`, or `dummy`)
   * `pocketsphinx` - configuration for [Pocketsphinx](speech-to-text.md#pocketsphinx)
     * `compatible` - true if profile can use pocketsphinx for speech recognition
-    * `acoustic_model` - directory with CMU 16Khz acoustic model
+    * `acoustic_model` - directory with CMU 16 kHz acoustic model
     * `base_dictionary` - large text file with word pronunciations (read only)
     * `custom_words` - small text file with words/pronunciations added by user
     * `dictionary` - text file with all words/pronunciations needed for example sentences

--- a/docs/speech-to-text.md
+++ b/docs/speech-to-text.md
@@ -100,7 +100,7 @@ See `rhasspy.stt.RemoteDecoder` for details.
 
 ## MQTT/Hermes
 
-Publishes transcriptions to `hermes/asr/textCaptured` ([Hermes protocol](https://docs.snips.ai/ressources/hermes-protocol)) each time a voice command is spoken.
+Publishes transcriptions to `hermes/asr/textCaptured` ([Hermes protocol](https://docs.snips.ai/reference/hermes)) each time a voice command is spoken.
 
 This is enabled by default.
 

--- a/docs/tutorials.md
+++ b/docs/tutorials.md
@@ -177,35 +177,35 @@ Contributed by [jaburges](https://community.home-assistant.io/u/jaburges)
     (At time of writing I put Wakeword, voice detection and recognition on the client)
 14. Under settings ensure the following is selected, Save along the way. You will need to Train once also.
 
-            [Rhasspy]
-            Listen for wake word on Startup = checked
+        [Rhasspy]
+        Listen for wake word on Startup = checked
 
-            [Home Assistant]
-            Do not use Home Assistant (note you obviously can instead of Node-Red)
+        [Home Assistant]
+        Do not use Home Assistant (note you obviously can instead of Node-Red)
 
-            [Wake Word]
-            Use snowboy (this should trigger a download of more files)
+        [Wake Word]
+        Use snowboy (this should trigger a download of more files)
 
-            [Voice Detection]
-            Use webrtcvad and listen for silence
+        [Voice Detection]
+        Use webrtcvad and listen for silence
 
-            [Speech Recognition]
-            Use Remote Rhasspy server for speech recognition:
-            URL = http://<SERVER_IP>:12101/api/speech-to-text
+        [Speech Recognition]
+        Use Remote Rhasspy server for speech recognition:
+        URL = http://<SERVER_IP>:12101/api/speech-to-text
 
-            [Intent Recognition]
-            Use Remote Rhasspy server for speech recognition:
-            URL = http://<SERVER_IP>:12101/api/text-to-intent
+        [Intent Recognition]
+        Use Remote Rhasspy server for speech recognition:
+        URL = http://<SERVER_IP>:12101/api/text-to-intent
 
-            [Text to Speech]
-            No Text to speech on this device
+        [Text to Speech]
+        No Text to speech on this device
 
-            [Audio Recording]
-            Use PyAudio (default)
-            Input Device = seeed-4mic-voicecard (you can test this if you want)
+        [Audio Recording]
+        Use PyAudio (default)
+        Input Device = seeed-4mic-voicecard (you can test this if you want)
 
-            [Audio Playing]
-            No Playback on this device
+        [Audio Playing]
+        No Playback on this device
 
 ### Node-Red Config
 

--- a/docs/tutorials.md
+++ b/docs/tutorials.md
@@ -90,8 +90,8 @@ Contributed by [jaburges](https://community.home-assistant.io/u/jaburges)
               --user-profiles /profiles \
               --profile en
 
-3. Goto server URL `http://<Server_IP>:12101` (you may be asked to download files)
-4. Goto settings and check config (and save along the way):
+3. Go to server URL `http://<Server_IP>:12101` (you may be asked to download files)
+4. Go to settings and check configuration (and save along the way):
 
         [Rhasspy]
         Listen for wake word on Startup = UNchecked
@@ -139,7 +139,7 @@ Contributed by [jaburges](https://community.home-assistant.io/u/jaburges)
 
         git clone https://github.com/respeaker/seeed-voicecard
         cd seeed-voicecard
-        sudo ./install.sh 
+        sudo ./install.sh
         sudo reboot
 
 7. Plug in Seeed speaker and check install was successful against expected result here 5:
@@ -173,7 +173,7 @@ Contributed by [jaburges](https://community.home-assistant.io/u/jaburges)
               --user-profiles /profiles \
               --profile en
 
-13. Goto Client URL `http://<Pi_IP_address>:12101` (you will be asked to download some files)
+13. Go to Client URL `http://<Pi_IP_address>:12101` (you will be asked to download some files)
     (At time of writing I put Wakeword, voice detection and recognition on the client)
 14. Under settings ensure the following is selected, Save along the way. You will need to Train once also.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -166,7 +166,7 @@ For the `ChangLightState` intent from the [RGB Light Example](index.md#rgb-light
 
 ## MQTT and Snips
 
-Rhasspy is able to interoperate with Snips.AI services using the [Hermes protocol](https://docs.snips.ai/ressources/hermes-protocol) over [MQTT](http://mqtt.org). The following components are Snips/Hermes compatible:
+Rhasspy is able to interoperate with Snips.AI services using the [Hermes protocol](https://docs.snips.ai/reference/hermes) over [MQTT](http://mqtt.org). The following components are Snips/Hermes compatible:
 
 * [Microphone input](audio-input.md#mqtthermes)
 * [Wake word](wake-word.md#mqtthermes)

--- a/docs/wake-word.md
+++ b/docs/wake-word.md
@@ -158,7 +158,7 @@ See `rhasspy.wake.PreciseWakeListener` for details.
 
 ## MQTT/Hermes
 
-Subscribes to the `hermes/hotword/<WAKEWORD_ID>/detected` topic, and wakes Rhasspy up when a message is received ([Hermes protocol](https://docs.snips.ai/ressources/hermes-protocol)). This allows Rhasspy to use the wake word functionality in [Snips.AI](https://snips.ai/).
+Subscribes to the `hermes/hotword/<WAKEWORD_ID>/detected` topic, and wakes Rhasspy up when a message is received ([Hermes protocol](https://docs.snips.ai/reference/hermes)). This allows Rhasspy to use the wake word functionality in [Snips.AI](https://snips.ai/).
 
 Add to your [profile](profiles.md):
 

--- a/rhasspy/audio_player.py
+++ b/rhasspy/audio_player.py
@@ -160,7 +160,7 @@ class APlayAudioPlayer(RhasspyActor):
 
 # -----------------------------------------------------------------------------
 # MQTT audio player for Snips.AI Hermes Protocol
-# https://docs.snips.ai/ressources/hermes-protocol
+# https://docs.snips.ai/reference/hermes
 # -----------------------------------------------------------------------------
 
 

--- a/rhasspy/audio_recorder.py
+++ b/rhasspy/audio_recorder.py
@@ -565,7 +565,7 @@ class ARecordAudioRecorder(RhasspyActor):
 
 # -----------------------------------------------------------------------------
 # MQTT based audio "recorder" for Snips.AI Hermes Protocol
-# https://docs.snips.ai/ressources/hermes-protocol
+# https://docs.snips.ai/reference/hermes
 # -----------------------------------------------------------------------------
 
 

--- a/rhasspy/command_listener.py
+++ b/rhasspy/command_listener.py
@@ -400,7 +400,7 @@ class OneShotCommandListener(RhasspyActor):
 
 # -----------------------------------------------------------------------------
 # MQTT-Based Command Listener (Hermes Protocol)
-# https://docs.snips.ai/ressources/hermes-protocol
+# https://docs.snips.ai/reference/hermes
 # -----------------------------------------------------------------------------
 
 

--- a/rhasspy/mqtt.py
+++ b/rhasspy/mqtt.py
@@ -58,7 +58,7 @@ class MessageReady:
 
 # -----------------------------------------------------------------------------
 # Interoperability with Snips.AI Hermes protocol
-# https://docs.snips.ai/ressources/hermes-protocol
+# https://docs.snips.ai/reference/hermes
 # -----------------------------------------------------------------------------
 
 

--- a/rhasspy/wake.py
+++ b/rhasspy/wake.py
@@ -683,7 +683,7 @@ class PreciseWakeListener(RhasspyActor):
 
 # -----------------------------------------------------------------------------
 # MQTT-based wake listener (Hermes protocol)
-# https://docs.snips.ai/ressources/hermes-protocol
+# https://docs.snips.ai/reference/hermes
 # -----------------------------------------------------------------------------
 
 

--- a/src/components/profile/AudioPlaying.vue
+++ b/src/components/profile/AudioPlaying.vue
@@ -43,7 +43,7 @@
                     <div class="form-check">
                         <input class="form-check-input" type="radio" name="sounds-system" id="sounds-system-mqtt" value="hermes" v-model="profile.sounds.system">
                         <label class="form-check-label" for="sounds-system-mqtt">
-                            Play sound remotely with MQTT (<a href="https://docs.snips.ai/ressources/hermes-protocol">Hermes protocol</a>)
+                            Play sound remotely with MQTT (<a href="https://docs.snips.ai/reference/hermes">Hermes protocol</a>)
                         </label>
                     </div>
                 </div>

--- a/src/components/profile/AudioRecording.vue
+++ b/src/components/profile/AudioRecording.vue
@@ -64,7 +64,7 @@
                     <div class="form-check">
                         <input class="form-check-input" type="radio" name="profile.microphone.system" id="audio-system-mqtt" value="hermes" v-model="profile.microphone.system">
                         <label class="form-check-label" for="audio-system-mqtt">
-                            Get microphone input remotely with MQTT (<a href="https://docs.snips.ai/ressources/hermes-protocol">Hermes protocol</a>)
+                            Get microphone input remotely with MQTT (<a href="https://docs.snips.ai/reference/hermes">Hermes protocol</a>)
                         </label>
                     </div>
                 </div>

--- a/src/components/profile/Rhasspy.vue
+++ b/src/components/profile/Rhasspy.vue
@@ -24,7 +24,7 @@
                 <div class="form-row">
                     <input type="checkbox" id="mqtt-enabled" v-model="profile.mqtt.enabled">
                     <label for="mqtt-enabled" class="col-form-label">Enable MQTT</label>
-                    <span class="col-form-label text-muted">(<a href="https://docs.snips.ai/ressources/hermes-protocol">Snips.ai compatibility</a>)</span>
+                    <span class="col-form-label text-muted">(<a href="https://docs.snips.ai/reference/hermes">Snips.ai compatibility</a>)</span>
                 </div>
             </div>
             <div class="form-group">

--- a/src/components/profile/VoiceDetection.vue
+++ b/src/components/profile/VoiceDetection.vue
@@ -29,7 +29,7 @@
                     <div class="form-check">
                         <input class="form-check-input" type="radio" name="command-system" id="command-system-hermes" value="hermes" v-model="profile.command.system">
                         <label class="form-check-label" for="command-system-hermes">
-                            Use MQTT (<a href="https://docs.snips.ai/ressources/hermes-protocol">Hermes protocol</a>)
+                            Use MQTT (<a href="https://docs.snips.ai/reference/hermes">Hermes protocol</a>)
                         </label>
                     </div>
                 </div>

--- a/src/components/profile/WakeWord.vue
+++ b/src/components/profile/WakeWord.vue
@@ -148,7 +148,7 @@
                     <div class="form-check">
                         <input class="form-check-input" type="radio" name="wake-system" id="wake-system-hermes" value="hermes" v-model="profile.wake.system">
                         <label class="form-check-label" for="wake-system-hermes">
-                            Wake up on MQTT message (<a href="https://docs.snips.ai/ressources/hermes-protocol">Hermes protocol</a>)
+                            Wake up on MQTT message (<a href="https://docs.snips.ai/reference/hermes">Hermes protocol</a>)
                         </label>
                     </div>
                 </div>


### PR DESCRIPTION
There are still two issues someone else should take a look at:

- In docs/wake-word.md: https://github.com/Picovoice/Porcupine/tree/master/tools/optimizer doesn't exist anymore, apparently this functionality is now in the [Picovoice Console](https://console.picovoice.ai). Can anyone with access confirm this and fix the link and description in the documentation?
- In docs/tutorials.md: The link behind 'simplified JSGF grammar' refers to 'doc/sentences/md', which isn't a valid URL. What should this link be?