### PR TITLE
Change X-HASSIO-KEY to Authorization

### DIFF
--- a/rhasspy/utils.py
+++ b/rhasspy/utils.py
@@ -475,7 +475,7 @@ def hass_request_kwargs(
         headers["X-HA-Access"] = hass_config["api_password"]
     elif "HASSIO_TOKEN" in os.environ:
         # Use token from hass.io
-        headers["X-HASSIO-KEY"] = os.environ["HASSIO_TOKEN"]
+        headers["Authorization"] = "Bearer %s" % os.environ["HASSIO_TOKEN"]
 
     kwargs: Dict[str, Any] = {"headers": headers}
 


### PR DESCRIPTION
I have changed the X-HASSIO-KEY header to the Authorization header.

This, together with the homeassistant_api:true already in in tje config.json of the AddOn works correctly on my system. 
In general, this change is a more generic solution in my opinion