### PR TITLE
Only download Kaldi when it is requested to be installed.

### DIFF
--- a/build-from-source.sh
+++ b/build-from-source.sh
@@ -191,7 +191,7 @@ fi
 
 # Kaldi
 kaldi_dir="${this_dir}/opt/kaldi"
-if [[ ! -d "${kaldi_dir}" ]]; then
+if [[ -z "${no_kaldi}" &&  ! -d "${kaldi_dir}" ]]; then
     install libatlas-base-dev libatlas3-base gfortran
     run_sudo ldconfig
     kaldi_file="${download_dir}/kaldi-2019.tar.gz"


### PR DESCRIPTION
Build-from-source.sh downloads Kaldi and installs gfortran, also when Kaldi should not to be installed.
I suppose it's better to also check the no_kaldi flag when trying to download Kaldi.