### PR TITLE
Fuzzywuzzy: major speed improvement by disabling the debug log spam

### DIFF
--- a/rhasspy/intent.py
+++ b/rhasspy/intent.py
@@ -370,7 +370,6 @@ class FuzzyWuzzyRecognizer(RhasspyActor):
                     sentences = []
                     for example in intent_examples:
                         example_text = example.get("raw_text", example["text"])
-                        logging.debug(example_text)
                         choices[example_text] = (example_text, example)
                         sentences.append(example_text)
 


### PR DESCRIPTION
By removing a debug log line, the recognizing time of fuzzywuzzy can be drastically reduced.

Hardware: RaspberryPi 3.
The sentence count in the test setup: 100 - 200.
The recognition time changed from over 2 seconds to 320 ms. 

I also experimented with caching the sentences and choices, but this only reduced the time about 20ms, so I decided to keep it as is.