### PR TITLE
Install dependencies before running yarn build.

### DIFF
--- a/build-from-source.sh
+++ b/build-from-source.sh
@@ -398,5 +398,5 @@ esac
 
 if [[ -z "${no_web}" ]]; then
     echo "Building web interface"
-    cd "${this_dir}" && yarn build
+    cd "${this_dir}" && yarn install && yarn build
 fi


### PR DESCRIPTION
Install dependencies before running yarn build, otherwise it can't find them.