### PR TITLE
Wake Word: activation/deactivation over HTTP API and MQTT Hermes

### DIFF
--- a/app.py
+++ b/app.py
@@ -272,6 +272,23 @@ async def api_listen_for_wake() -> str:
     core.listen_for_wake()
     return "OK"
 
+# -----------------------------------------------------------------------------
+
+
+@app.route("/api/set-wake-word-detection", methods=["POST"])
+async def api_listen_for_wake_word() -> str:
+    """Activate/Deactivate the wake word detection"""
+    assert core is not None
+
+    data = await request.data
+    activeData = data.decode()
+    active = activeData.lower() == "true"
+    if active:
+        core.activate_wake_word_detection()
+    else:
+        core.deactivate_wake_word_detection()
+
+    return "OK"
 
 # -----------------------------------------------------------------------------
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -54,6 +54,8 @@ Application authors may want to use the [rhasspy-client](https://pypi.org/projec
     * `?entity=<entity>&value=<value>` - set custom entity/value in recognized intent
 * `/api/listen-for-wake-word`
     * POST to wake Rhasspy up and return immediately
+* `/api/set-wake-word-detection`
+    * POST "true" or "false" to activate/deactivate the wake word detection
 * `/api/lookup`
     * POST word as plain text to look up or guess pronunciation
     * `?n=<number>` - return at most `n` guessed pronunciations
@@ -146,6 +148,12 @@ Rhasspy implements part of the [Hermes](https://docs.snips.ai/reference/hermes) 
     * Rhasspy publishes a transcription to this topic each time a voice command is recognized.
 * `hermes/hotword/<WAKEWORD_ID>/detected`
     * Rhasspy wakes up when a message is received on this topic.
+* `hermes/hotword/toggleOn`
+    * Rhasspy activates the wake word detection
+    * The payload is a JSON object with a `siteId` key that holds Rhasspy's site ID.
+* `hermes/hotword/toggleOff`
+    * Rhasspy deactivates the wake word detection
+    * The payload is a JSON object with a `siteId` key that holds Rhasspy's site ID.
 
 ## Command Line
 

--- a/rhasspy/core.py
+++ b/rhasspy/core.py
@@ -51,6 +51,8 @@ from rhasspy.events import (
     WordPhonemes,
     WordPronunciations,
     WordSpoken,
+    ActivateWakeWordDetection,
+    DeactivateWakeWordDetection,
 )
 from rhasspy.profiles import Profile
 from rhasspy.utils import numbers_to_words
@@ -166,6 +168,16 @@ class RhasspyCore:
         """Tell Rhasspy to start listening for a wake word."""
         assert self.actor_system is not None
         self.actor_system.tell(self.dialogue_manager, ListenForWakeWord())
+
+    def activate_wake_word_detection(self) -> None:
+        """Tell Rhasspy to stop listening for a wake word."""
+        assert self.actor_system is not None
+        self.actor_system.tell(self.dialogue_manager, ActivateWakeWordDetection())
+
+    def deactivate_wake_word_detection(self) -> None:
+        """Tell Rhasspy to stop listening for a wake word."""
+        assert self.actor_system is not None
+        self.actor_system.tell(self.dialogue_manager, DeactivateWakeWordDetection())
 
     async def listen_for_command(
         self,

--- a/rhasspy/events.py
+++ b/rhasspy/events.py
@@ -9,6 +9,22 @@ from rhasspy.actor import RhasspyActor
 # Wake
 # -----------------------------------------------------------------------------
 
+class ActivateWakeWordDetection:
+    """Request to activate the wake word detection."""
+
+    def __init__(self, receiver: Optional[RhasspyActor] = None, record=True) -> None:
+        self.receiver = receiver
+        self.record = record
+
+
+class DeactivateWakeWordDetection:
+    """Request to deactivate the wake word detection."""
+
+    def __init__(
+        self, receiver: Optional[RhasspyActor] = None, record=True) -> None:
+        self.receiver = receiver
+        self.record = record
+
 
 class ListenForWakeWord:
     """Request to start listening for a wake word."""


### PR DESCRIPTION
This is a proposal for the wake word activation/deactivation handling over HTTP and MQTT Hermes
I used this feature with Snips and I miss it currently with Rhasspy.

* added new HTTP API call: /api/set-wake-word-detection
* implemented MQTT Hermes topics:  hermes/hotword/toggleOn, hermes/hotword/toggleOff