### PR TITLE
Give a hint to lame about mp3 files

### DIFF
--- a/rhasspy/tts.py
+++ b/rhasspy/tts.py
@@ -896,7 +896,7 @@ class HomeAssistantSentenceSpeaker(RhasspyActor):
 
             # Convert to WAV
             if audio_url.endswith(".mp3"):
-                lame_command = ["lame", "--decode", "-", "-"]
+                lame_command = ["lame", "--decode", "--mp3input", "-", "-"]
                 self._logger.debug(lame_command)
 
                 return subprocess.run(


### PR DESCRIPTION
Apparently, when given audio through stdin, lame can't detect the file type correctly some times. A quick fix is to add --mp3input to the command line (we have checked for file extension anyway, so...)