### PR TITLE
Add yarn install before build

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -124,7 +124,7 @@ pip3 install -r requirements.txt
 You should also re-build the web interface:
 
 1. Install [yarn](https://yarnpkg.com) on your system
-2. Run `yarn build` in the `rhasspy` directory
+2. Run `yarn install && yarn build` in the `rhasspy` directory
 3. Restart any running instances of Rhasspy
 
 ### Running as a Service


### PR DESCRIPTION
Without yarn install you get this:
```
~/rhasspy$ yarn build
yarn run v1.21.1
$ vue-cli-service build
/bin/sh: 1: vue-cli-service: not found
error Command failed with exit code 127.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```