### PR TITLE
Fix Rasa tag synonyms

### DIFF
--- a/rhasspy/intent_train.py
+++ b/rhasspy/intent_train.py
@@ -197,7 +197,11 @@ class RasaIntentTrainer(RhasspyActor):
                         if entity and (raw_index >= entity["raw_end"]):
                             # Finish current entity
                             last_token = entity_tokens[-1]
-                            entity_tokens[-1] = f"{last_token}]({entity['entity']})"
+                            if entity['value'] != entity['raw_value']:
+                                synonym = f":{entity['value']}"
+                            else:
+                                synonym = ""
+                            entity_tokens[-1] = f"{last_token}]({entity['entity']}{synonym})"
                             sentence_tokens.extend(entity_tokens)
                             entity = None
                             entity_tokens = []
@@ -222,7 +226,11 @@ class RasaIntentTrainer(RhasspyActor):
                     if entity:
                         # Finish final entity
                         last_token = entity_tokens[-1]
-                        entity_tokens[-1] = f"{last_token}]({entity['entity']})"
+                        if entity['value'] != entity['raw_value']:
+                            synonym = f":{entity['value']}"
+                        else:
+                            synonym = ""
+                        entity_tokens[-1] = f"{last_token}]({entity['entity']}{synonym})"
                         sentence_tokens.extend(entity_tokens)
 
                     # Print single example


### PR DESCRIPTION
When using slots like this:
```
(playlist long name):PlaylistName
```

Used as:
```
($playlist){playlist}
```

It is converted to Rasa training format like this:

```
[playlist long name](playlist)
```

That results in resolving the entity incorrectly, as "playlist long name" instead of "PlaylistName".
This patch fixes that by adding a synonym for Rasa:

```
  ## intent:...
  - [playlist long name](playlist:PlaylistName)
```