### PR TITLE
Support MQTT over TLS

### DIFF
--- a/docs/audio-input.md
+++ b/docs/audio-input.md
@@ -69,7 +69,15 @@ Add to your [profile](profiles.md):
   "username": "",
   "port": 1883,
   "password": "",
-  "site_id": "default"
+  "site_id": "default",
+  "tls": {
+    "enabled": false,
+    "ca_certs": "",
+    "cert_reqs": "CERT_REQUIRED",
+    "certfile": "",
+    "ciphers": "",
+    "keyfile": ""
+  }
 }
 ```
 

--- a/docs/audio-output.md
+++ b/docs/audio-output.md
@@ -44,7 +44,15 @@ Add to your [profile](profiles.md):
   "username": "",
   "port": 1883,
   "password": "",
-  "site_id": "default"
+  "site_id": "default",
+  "tls": {
+    "enabled": false,
+    "ca_certs": "",
+    "cert_reqs": "CERT_REQUIRED",
+    "certfile": "",
+    "ciphers": "",
+    "keyfile": ""
+  }
 }
 ```
 

--- a/docs/command-listener.md
+++ b/docs/command-listener.md
@@ -86,7 +86,15 @@ Add to your [profile](profiles.md):
   "username": "",
   "port": 1883,
   "password": "",
-  "site_id": "default"
+  "site_id": "default",
+  "tls": {
+    "enabled": false,
+    "ca_certs": "",
+    "cert_reqs": "CERT_REQUIRED",
+    "certfile": "",
+    "ciphers": "",
+    "keyfile": ""
+  }
 }
 ```
 

--- a/docs/intent-handling.md
+++ b/docs/intent-handling.md
@@ -93,14 +93,22 @@ Add to your [profile](profiles.md):
 
 ```json
 "mqtt": {
-    "enabled": true,
-    "host": "localhost",
-    "username": "",
-    "password": "",
-    "port": 1883,
-    "reconnect_sec": 5,
-    "site_id": "default",
-    "publish_intents": true
+  "enabled": true,
+  "host": "localhost",
+  "username": "",
+  "password": "",
+  "port": 1883,
+  "reconnect_sec": 5,
+  "site_id": "default",
+  "publish_intents": true,
+  "tls": {
+    "enabled": false,
+    "ca_certs": "",
+    "cert_reqs": "CERT_REQUIRED",
+    "certfile": "",
+    "ciphers": "",
+    "keyfile": ""
+  }
 }
 ```
 

--- a/docs/wake-word.md
+++ b/docs/wake-word.md
@@ -181,7 +181,15 @@ Add to your [profile](profiles.md):
   "username": "",
   "port": 1883,
   "password": "",
-  "site_id": "default"
+  "site_id": "default",
+  "tls": {
+    "enabled": false,
+    "ca_certs": "",
+    "cert_reqs": "CERT_REQUIRED",
+    "certfile": "",
+    "ciphers": "",
+    "keyfile": ""
+  }
 }
 ```
 

--- a/profiles/defaults.json
+++ b/profiles/defaults.json
@@ -119,7 +119,15 @@
     "publish_intents": true,
     "reconnect_sec": 5,
     "site_id": "default",
-    "username": ""
+    "username": "",
+    "tls": {
+      "enabled": false,
+      "ca_certs": "",
+      "cert_reqs": "CERT_REQUIRED",
+      "certfile": "",
+      "ciphers": "",
+      "keyfile": ""
+    }
   },
   "rhasspy": {
     "listen_on_start": true,

--- a/rhasspy/profile_schema.json
+++ b/rhasspy/profile_schema.json
@@ -417,7 +417,18 @@
             "reconnect_sec": { "type": "integer", "min": 0 },
             "site_id": { "type": "string" },
             "username": { "type": "string" },
-            "publish_intents": { "type": "boolean" }
+            "publish_intents": { "type": "boolean" },
+            "tls": {
+                "type": "dict",
+                "schema": {
+                    "enabled": { "type": "boolean" },
+                    "ca_certs": { "type": "string" },
+                    "cert_reqs": { "type": "string" },
+                    "certfile": { "type": "string" },
+                    "ciphers": { "type": "string" },
+                    "keyfile": { "type": "string" }
+                }
+            }
         }
     },
 

--- a/src/assets/ProfileDefaults.js
+++ b/src/assets/ProfileDefaults.js
@@ -109,7 +109,15 @@ const profileDefaults = {
         "reconnect_sec": 5,
         "site_id": "default",
         "username": "",
-        "publish_intents": true
+        "publish_intents": true,
+        "tls": {
+            "enabled": false,
+            "ca_certs": "",
+            "cert_reqs": "CERT_REQUIRED",
+            "certfile": "",
+            "ciphers": "",
+            "keyfile": ""
+        }
     },
     "rhasspy": {
         "default_profile": "en",

--- a/src/components/profile/Rhasspy.vue
+++ b/src/components/profile/Rhasspy.vue
@@ -72,6 +72,58 @@
             </div>
             <div class="form-group">
                 <div class="form-row">
+                    <input id="mqtt-tls-enabled" type="checkbox" v-model="profile.mqtt.tls.enabled" :disabled="!profile.mqtt.enabled">
+                    <label for="mqtt-tls-enabled" class="col-form-label">Enable MQTT over TLS</label>
+                </div>
+            </div>
+            <template v-if="profile.mqtt.tls.enabled">
+                <div class="form-group">
+                    <div class="form-row">
+                        <label for="mqtt-tls-ca_certs" class="col-form-label">ca_certs</label>
+                        <div class="col-sm-auto">
+                            <input id="mqtt-tls-ca_certs" type="text" class="form-control" v-model="profile.mqtt.tls.ca_certs" :disabled="!profile.mqtt.enabled">
+                        </div>
+                    </div>
+                </div>
+                <div class="form-group">
+                    <div class="form-row">
+                        <label for="mqtt-tls-cert_reqs" class="col-form-label">cert_reqs</label>
+                        <div class="col-sm-auto">
+                            <select id="mqtt-tls-cert_reqs" v-model="profile.mqtt.tls.cert_reqs" :disabled="!profile.mqtt.enabled">
+                                <option value="CERT_REQUIRED" default>CERT_REQUIRED</option>
+                                <option value="CERT_OPTIONAL">CERT_OPTIONAL</option>
+                                <option value="CERT_NONE">CERT_NONE</option>
+                            </select>
+                        </div>
+                    </div>
+                </div>
+                <div class="form-group">
+                    <div class="form-row">
+                        <label for="mqtt-tls-certfile" class="col-form-label">certfile</label>
+                        <div class="col-sm-auto">
+                            <input id="mqtt-tls-certfile" type="text" class="form-control" v-model="profile.mqtt.tls.certfile" :disabled="!profile.mqtt.enabled">
+                        </div>
+                    </div>
+                </div>
+                <div class="form-group">
+                    <div class="form-row">
+                        <label for="mqtt-tls-ciphers" class="col-form-label">ciphers</label>
+                        <div class="col-sm-auto">
+                            <input id="mqtt-tls-ciphers" type="text" class="form-control" v-model="profile.mqtt.tls.ciphers" :disabled="!profile.mqtt.enabled">
+                        </div>
+                    </div>
+                </div>
+                <div class="form-group">
+                    <div class="form-row">
+                        <label for="mqtt-tls-keyfile" class="col-form-label">keyfile</label>
+                        <div class="col-sm-auto">
+                            <input id="mqtt-tls-keyfile" type="text" class="form-control" v-model="profile.mqtt.tls.keyfile" :disabled="!profile.mqtt.enabled">
+                        </div>
+                    </div>
+                </div>
+            </template>
+            <div class="form-group">
+                <div class="form-row">
                     <input type="checkbox" id="mqtt-publish_intents" v-model="profile.mqtt.publish_intents" :disabled="!profile.mqtt.enabled">
                     <label for="mqtt-publish_intents" class="col-form-label">Publish intents over MQTT</label>
                 </div>


### PR DESCRIPTION
Allows the user to input `paho` TLS settings, to connect to `mqtts` servers.

Fixes #202 